### PR TITLE
Option to use coherent instances by default

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,6 @@ jobs:
         os: [ubuntu-latest, macOS-latest, windows-latest]
         cabal: ["3.2"]
         ghc:
-          - "7.10"
           - "8.0"
           - "8.2"
           - "8.4"
@@ -33,8 +32,6 @@ jobs:
             ghc: 8.2
           - os: macOS-latest
             ghc: 8.0
-          - os: macOS-latest
-            ghc: 7.10
           - os: windows-latest
             ghc: 8.10
           - os: windows-latest
@@ -45,8 +42,6 @@ jobs:
             ghc: 8.2
           - os: windows-latest
             ghc: 8.0
-          - os: windows-latest
-            ghc: 7.10
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,7 +67,7 @@ jobs:
       run: |
         cabal freeze
 
-    - uses: actions/cache@v2.1.3
+    - uses: actions/cache@v2
       name: Cache ~/.cabal/store
       with:
         path: ${{ steps.setup-haskell-cabal.outputs.cabal-store }}
@@ -109,7 +109,7 @@ jobs:
         ghc-version: ${{ matrix.ghc }}
         stack-version: ${{ matrix.stack }}
 
-    - uses: actions/cache@v2.1.3
+    - uses: actions/cache@v2
       name: Cache ~/.stack
       with:
         path: ~/.stack

--- a/examples/generic.hs
+++ b/examples/generic.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE CPP #-}
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE FlexibleContexts #-}
@@ -6,9 +5,6 @@
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE UndecidableInstances #-}
-#if __GLASGOW_HASKELL__ < 710
-{-# LANGUAGE OverlappingInstances #-}
-#endif
 
 import GHC.Generics (Generic)
 import Test.QuickCheck

--- a/generic-random.cabal
+++ b/generic-random.cabal
@@ -53,6 +53,17 @@ test-suite unit
   type: exitcode-stdio-1.0
   default-language: Haskell2010
 
+test-suite coherence
+  hs-source-dirs:  test
+  main-is:         coherence.hs
+  build-depends:
+    base,
+    deepseq,
+    QuickCheck,
+    generic-random
+  type: exitcode-stdio-1.0
+  default-language: Haskell2010
+
 test-suite inspect
   hs-source-dirs:  test
   main-is:         Inspect.hs

--- a/generic-random.cabal
+++ b/generic-random.cabal
@@ -23,7 +23,7 @@ category:            Generics, Testing
 build-type:          Simple
 extra-source-files:  README.md CHANGELOG.md
 cabal-version:       >=1.10
-tested-with:         GHC == 7.8.4, GHC == 7.10.3, GHC == 8.0.1, GHC == 8.2.1, GHC == 8.4.1, GHC == 8.6.1
+tested-with:         GHC == 8.0.1, GHC == 8.0.2, GHC == 8.2.1, GHC == 8.4.1, GHC == 8.6.1
 
 library
   hs-source-dirs:      src
@@ -33,7 +33,7 @@ library
     Generic.Random.Internal.Generic
     Generic.Random.Tutorial
   build-depends:
-    base >= 4.7 && < 5,
+    base >= 4.9 && < 5,
     QuickCheck
   default-language:    Haskell2010
   ghc-options: -Wall -fno-warn-name-shadowing

--- a/src/Generic/Random.hs
+++ b/src/Generic/Random.hs
@@ -27,7 +27,6 @@
 -- - "Generic.Random.Tutorial"
 -- - http://blog.poisson.chat/posts/2018-01-05-generic-random-tour.html
 
-{-# LANGUAGE CPP #-}
 {-# LANGUAGE ExplicitNamespaces #-}
 
 module Generic.Random
@@ -150,12 +149,10 @@ module Generic.Random
     -- Multiple generators may match a given field: the first, leftmost
     -- generator in the list will be chosen.
   , (:+) (..)
-#if __GLASGOW_HASKELL__ >= 800
   , FieldGen (..)
   , fieldGen
   , ConstrGen (..)
   , constrGen
-#endif
   , Gen1 (..)
   , Gen1_ (..)
 

--- a/src/Generic/Random.hs
+++ b/src/Generic/Random.hs
@@ -28,6 +28,7 @@
 -- - http://blog.poisson.chat/posts/2018-01-05-generic-random-tour.html
 
 {-# LANGUAGE CPP #-}
+{-# LANGUAGE ExplicitNamespaces #-}
 
 module Generic.Random
   (
@@ -171,6 +172,11 @@ module Generic.Random
   , Options ()
   , genericArbitraryWith
 
+    -- ** Setters
+  , SetOptions
+  , type (<+)
+  , setOpts
+
     -- ** Size modifiers
   , Sizing (..)
   , SetSized
@@ -182,6 +188,10 @@ module Generic.Random
   , SetGens
   , setGenerators
 
+    -- ** Coherence options
+  , Coherence (..)
+  , Incoherent (..)
+
     -- ** Common options
   , SizedOpts
   , sizedOpts
@@ -189,6 +199,13 @@ module Generic.Random
   , sizedOptsDef
   , UnsizedOpts
   , unsizedOpts
+
+    -- *** Advanced options
+    -- | See 'Coherence'
+  , CohUnsizedOpts
+  , cohUnsizedOpts
+  , CohSizedOpts
+  , cohSizedOpts
 
     -- * Generic classes
   , GArbitrary

--- a/src/Generic/Random/Internal/BaseCase.hs
+++ b/src/Generic/Random/Internal/BaseCase.hs
@@ -1,7 +1,6 @@
 {-# OPTIONS_HADDOCK not-home #-}
 
 {-# LANGUAGE AllowAmbiguousTypes #-}
-{-# LANGUAGE CPP #-}
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DefaultSignatures #-}
 {-# LANGUAGE FlexibleContexts #-}
@@ -13,9 +12,6 @@
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
-#if __GLASGOW_HASKELL__ < 710
-{-# LANGUAGE OverlappingInstances #-}
-#endif
 
 -- | Base case discovery.
 --
@@ -30,12 +26,7 @@
 module Generic.Random.Internal.BaseCase where
 
 import Control.Applicative
-#if __GLASGOW_HASKELL__ >= 800
 import Data.Proxy
-#endif
-#if __GLASGOW_HASKELL__ < 710
-import Data.Word
-#endif
 import GHC.Generics
 import GHC.TypeLits
 import Test.QuickCheck
@@ -298,7 +289,6 @@ instance (y ~ 'Nothing) => GBCS (K1 i c) 0 y e where
 instance (y ~ 'Just 0) => GBCS U1 z y e where
   gbcs _ _ = pure U1
 
-#if __GLASGOW_HASKELL__ >= 800
 instance {-# INCOHERENT #-}
   ( TypeError
       (     'Text "Unrecognized Rep: "
@@ -312,7 +302,6 @@ instance {-# INCOHERENT #-}
   , Alternative (IfM y Weighted Proxy)
   ) => GBCS f z y e where
   gbcs = error "Type error"
-#endif
 
 class GBaseCaseSearch a z y e where
   gBaseCaseSearch :: prox y -> proxy '(z, e) -> IfM y Gen Proxy a
@@ -323,18 +312,3 @@ instance (Generic a, GBCS (Rep a) z y e, IsMaybe y)
     (\(Weighted (Just (g, n))) -> choose (0, n-1) >>= fmap to . g)
     (\Proxy -> Proxy)
     (gbcs y z)
-
-#if __GLASGOW_HASKELL__ < 800
-data Proxy a = Proxy
-
-instance Functor Proxy where
-  fmap _ _ = Proxy
-
-instance Applicative Proxy where
-  pure _ = Proxy
-  _ <*> _ = Proxy
-
-instance Alternative Proxy where
-  empty = Proxy
-  _ <|> _ = Proxy
-#endif

--- a/src/Generic/Random/Tutorial.hs
+++ b/src/Generic/Random/Tutorial.hs
@@ -58,9 +58,6 @@
 --
 -- == Typed weights
 --
--- /GHC 8.0.1 and above only (base ≥ 4.9)./ For compatibility, the annotations
--- are still allowed on older GHC versions, but ignored.
---
 -- The weights actually have type @'W' \"ConstructorName\"@ (just a newtype
 -- around 'Int'), so that you can annotate a weight with its corresponding
 -- constructor. The constructors must appear in the same order as in the
@@ -283,10 +280,7 @@
 -- Suggestions to add more modifiers or otherwise improve this tutorial are welcome!
 -- <https://github.com/Lysxia/generic-random/issues The issue tracker is this way.>
 
-{-# LANGUAGE CPP #-}
-#if __GLASGOW_HASKELL__ >= 800
 {-# OPTIONS_GHC -Wno-unused-imports #-}
-#endif
 
 module Generic.Random.Tutorial () where
 

--- a/src/Generic/Random/Tutorial.hs
+++ b/src/Generic/Random/Tutorial.hs
@@ -155,7 +155,7 @@
 -- where the depth of a constructor is defined as @1 + max(0, depths of fields)@,
 -- e.g., @Leaf ()@ has depth 2.
 --
--- == Note about lists
+-- == Note about lists #notelists#
 --
 -- The @Arbitrary@ instance for lists can be problematic for this way
 -- of implementing recursive sized generators, because they make a lot of

--- a/test/Unit.hs
+++ b/test/Unit.hs
@@ -1,5 +1,4 @@
 {-# LANGUAGE
-    CPP,
     DataKinds,
     DeriveGeneric,
     FlexibleContexts,
@@ -57,7 +56,6 @@ eval name g = do
     Just _ -> return ()
     Nothing -> fail $ name ++ ": did not finish on time"
 
-#if __GLASGOW_HASKELL__ >= 800
 -- Tests for ConstrGen
 
 data Tree2 = Leaf2 Int | Node2 Tree2 Tree2 deriving (Generic, Show)
@@ -69,13 +67,10 @@ isLeftBiased :: Tree2 -> Bool
 isLeftBiased (Leaf2 _) = True
 isLeftBiased (Node2 t (Leaf2 _)) = isLeftBiased t
 isLeftBiased _ = False
-#endif
 
 main :: IO ()
 main = do
   eval "B" (arbitrary :: Gen B)
   eval "T" (arbitrary :: Gen (T (T Int)))
   eval "NTree" (arbitrary :: Gen NTree)
-#if __GLASGOW_HASKELL__ >= 800
   quickCheck . whenFail (putStrLn "Tree2") $ isLeftBiased
-#endif

--- a/test/coherence.hs
+++ b/test/coherence.hs
@@ -1,0 +1,126 @@
+{-# OPTIONS_GHC -fdefer-type-errors -Wno-deferred-type-errors #-}
+{-# LANGUAGE
+    BangPatterns,
+    DataKinds,
+    DeriveGeneric,
+    ScopedTypeVariables,
+    TypeOperators,
+    RebindableSyntax,
+    TypeApplications #-}
+
+import Control.Monad (replicateM)
+import Control.Exception
+import System.Exit (exitFailure)
+import Data.Foldable (find, traverse_)
+import Data.Maybe (catMaybes)
+
+import GHC.Generics ( Generic )
+import Test.QuickCheck (Arbitrary (..), Gen, sample, generate)
+import Prelude
+
+import Generic.Random
+
+-- @T0@, @T1@: Override the @Int@ generator in the presence of a type parameter @a@.
+
+-- Counterexample that's not supposed to type check.
+-- Use BangPatterns so we can force it with just seq.
+data T0 a = N0 !a !Int
+  deriving (Generic, Show)
+
+instance Arbitrary a => Arbitrary (T0 a) where
+  arbitrary = genericArbitraryWith
+      (setGenerators customGens cohSizedOpts)
+      uniform
+    where
+      customGens :: Gen Int
+      customGens = pure 33
+
+
+-- This one works.
+data T1 a = N1 a Int
+  deriving (Generic, Show)
+
+instance Arbitrary a => Arbitrary (T1 a) where
+  arbitrary = genericArbitraryWith
+      (setGenerators customGens cohSizedOpts)
+      uniform
+    where
+      customGens :: Incoherent (Gen a) :+ Gen Int
+      customGens = Incoherent arbitrary :+ pure 33
+
+check1 :: T1 a -> Bool
+check1 (N1 _ n) = n == 33
+
+
+-- A bigger example to cover the remaining generator types.
+data T2 a = N2
+  { f2a :: a
+  , f2b :: Int
+  , f2c :: [Int]
+  , f2d :: Maybe Int
+  , f2e :: Int
+  , f2g :: Int
+  , f2h :: [a]
+  } deriving (Show, Generic)
+
+instance Arbitrary a => Arbitrary (T2 a) where
+  arbitrary = genericArbitraryWith
+      (setGenerators customGens cohSizedOpts)
+      uniform
+    where
+      -- Hack to allow annotating each generator in the list while avoiding parentheses
+      (>>) = (:+)
+      customGens = do
+        Incoherent arbitrary :: Incoherent (Gen a)
+        Incoherent (FieldGen ((: []) <$> arbitrary))
+                             :: Incoherent (FieldGen "f2h" [a])
+        Gen1_ (pure Nothing) :: Gen1_ Maybe
+        Gen1 (fmap (\x -> [x, x])) :: Gen1 []
+        ConstrGen (pure 88)  :: ConstrGen "N2" 4 Int
+        FieldGen  (pure 77)  :: FieldGen "f2g" Int
+        pure 33              :: Gen Int
+
+check2 :: T2 a -> Bool
+check2 t =
+     f2b t == 33
+  && length (f2c t) == 2
+  && f2d t == Nothing
+  && f2e t == 88
+  && f2g t == 77
+  && length (f2h t) == 1
+
+
+type Error = String
+
+expectTypeError :: IO a -> IO (Maybe Error)
+expectTypeError gen = do
+  r <- try (gen >>= evaluate)
+  case r of
+    Left (e :: TypeError) -> pure Nothing  -- success
+    Right _ -> (pure . Just) "Unexpected evaluation (expected a type error)"
+
+
+sample_ :: Show a => (a -> Bool) -> Gen a -> IO (Maybe Error)
+sample_ check g = do
+  xs <- generate (replicateM 100 g)
+  case find (not . check) xs of
+    Nothing -> pure Nothing
+    Just x -> (pure . Just) ("Invalid value: " ++ show x)
+
+
+collectErrors :: [IO (Maybe Error)] -> IO ()
+collectErrors xs = do
+  es <- sequence xs
+  case catMaybes es of
+    [] -> pure ()
+    es@(_ : _) -> do
+      putStrLn "Test failed. Errors:"
+      traverse_ putStrLn es
+      exitFailure
+
+main :: IO ()
+main = collectErrors
+  [ expectTypeError (generate (arbitrary :: Gen (T0 ())))
+  , sample_ check1 (arbitrary :: Gen (T1 ()))
+  , sample_ check2 (arbitrary :: Gen (T2 ()))
+  ]


### PR DESCRIPTION
Generic libraries that mess with the fields of parameterized types must use incoherent instances if they don't want to leak constraints that also make instances behave non-parametrically.

This does work 99.99% in practice, but relies on ([publicly documented](https://downloads.haskell.org/ghc/latest/docs/html/users_guide/glasgow_exts.html#overlapping-instances)) implementation details of GHC about incoherent instances.

Incoherence is inherent to the behavior I want to have, but I think there is a solution with more robust (weaker) assumptions about the type system, at the cost of some user inconvenience. Instead of coherence, we really want (local) uniqueness: if the instance solver finds a solution, then it's the only one.

In particular, if users set things up correctly (with incoherent instances provided by themselves rather than built into the library), custom generators cannot accidentally be ignored. While the current implementation also guarantees that in practice, this is only thanks to (what I consider) an implementation detail of GHC. If we forget those details, there are generally other solutions that ignore the custom generators.

---

TODO:

- [x] Figure out why `test/Test/Tree.hs` compiles (it shouldn't without more modification); I wonder whether I'm running into the (unfixable) bug which makes overlapping instances actually incoherent.
- [x] Add `ArbitraryOr` instance for `Incoherent`.
